### PR TITLE
Renames the entry point and updates version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY . .
 EXPOSE 3000
 
 # Command to run the application using the installed entry point
-CMD ["mcp-server-unifi-network"]
+CMD ["unifi-network-mcp"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unifi-network-mcp"
-version = "0.1.0b6"
+version = "0.1.0b7"
 description = "Unifi Network MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -31,4 +31,4 @@ dev-dependencies = [
 
 [project.scripts]
 # CLI entrypoint that launches the UniFi Network MCP server
-mcp-server-unifi-network = "src.main:main"
+unifi-network-mcp = "src.main:main"


### PR DESCRIPTION
This pull request includes updates to the project configuration and entry points to align with a new naming convention for the application. The most important changes involve renaming the CLI entry point and updating the Dockerfile and project metadata to reflect the new name.

### Naming convention updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L19-R19): Updated the command to run the application from `mcp-server-unifi-network` to `unifi-network-mcp` to match the new naming convention.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L34-R34): Renamed the CLI entry point from `mcp-server-unifi-network` to `unifi-network-mcp` under the `[project.scripts]` section.

### Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Incremented the project version from `0.1.0b6` to `0.1.0b7` to signify a new release.