### PR TITLE
BUG - no results being return on initial load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ aiounifi/*
 aiounifi
 
 .env.template
+claude_config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,22 @@ WORKDIR /app
 RUN pip install --upgrade pip \
  && pip install uv
 
-#Copy only metadata to leverage layer caching
+# Copy only metadata to leverage layer caching
 COPY pyproject.toml README.md ./
 
-# bring in package code
+# Bring in package code needed for installation
 COPY src ./src
 
-#build & install packages
+# Build & install package (pulls aiounifi from PyPI per pyproject)
 RUN pip install .
 
-#bring in the rest of the code
-COPY . .
+# Do NOT copy the entire repository to avoid shadowing installed deps with
+# similarly named top-level folders (e.g., aiounifi/). If you need runtime
+# config defaults available without a bind mount, copy only config.
+COPY src/config ./src/config
 
-#Expose the MCP server port
+# Expose the MCP server port (for optional HTTP SSE mode)
 EXPOSE 3000
 
-#console-script entrypoint
+# Console-script entrypoint
 CMD ["unifi-network-mcp"]

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ A self-hosted [Model Context Protocol](https://github.com/modelcontextprotocol) 
 
 * Full catalog of UniFi controller operations – firewall, traffic-routes, port-forwards, QoS, VPN, WLANs, stats, devices, clients **and more**.
 * All mutating tools require `confirm=true` so nothing can change your network by accident.
-* Works over **stdio** (FastMCP) *and* exposes an SSE HTTP endpoint (defaults to `:3000`).
-* One-liner launch via the console-script **`mcp-server-unifi-network`**.
+* Works over **stdio** (FastMCP). Optional SSE HTTP endpoint can be enabled via config.
+* One-liner launch via the console-script **`unifi-network-mcp`**.
 * Idiomatic Python ≥ 3.10, packaged with **pyproject.toml** and ready for PyPI.
 
 ---
@@ -81,7 +81,7 @@ uv pip install --no-deps -e .
 cp .env.example .env  # then edit values
 
 # 4. Launch
-mcp-server-unifi-network
+unifi-network-mcp
 ```
 
 ### Install from PyPI
@@ -145,6 +145,24 @@ After editing the config **restart Claude Desktop**, then test with:
 ```text
 @unifi-network-mcp list tools
 ```
+
+Note about Docker builds:
+
+- The image deliberately avoids copying the entire repository into the container to prevent vendored libraries (like a local `aiounifi/` folder) from shadowing PyPI dependencies. If you override the container’s filesystem (e.g., with a bind mount), avoid mounting the repo root; mount only what you need, such as `src/config` for configuration files.
+
+### Optional HTTP SSE endpoint (off by default)
+
+For environments where HTTP is acceptable (e.g., local development), you can enable the HTTP SSE server and expose it explicitly:
+
+```bash
+docker run -i --rm \
+  -p 3000:3000 \
+  -e UNIFI_MCP_HTTP_ENABLED=true \
+  ...
+  ghcr.io/sirkirby/unifi-network-mcp:latest
+```
+
+Security note: Leave this disabled in production or sensitive environments. The stdio transport remains the default and recommended mode.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ unifi-network-mcp
 uv pip install unifi-network-mcp  # or: pip install unifi-network-mcp
 ```
 
-The `mcp-server-unifi-network` entry-point will be added to your `$PATH`.
+The `unifi-network-mcp` entry-point will be added to your `$PATH`.
 
 ---
 
@@ -140,15 +140,32 @@ Add (or update) the `unifi-network-mcp` block under `mcpServers` in your `claude
 }
 ```
 
+### Option 3 – Claude attaches to an existing Docker container (recommended for compose)
+
+1) Using the container name as specified in `docker-compose.yml` from the repository root:
+
+```yaml
+docker-compose up --build
+```
+
+2) Then configure Claude Desktop:
+
+```jsonc
+"unifi-network-mcp": {
+  "command": "docker",
+  "args": ["exec", "-i", "unifi-network-mcp", "unifi-network-mcp"]
+}
+```
+
+Notes:
+- Use `-T` only with `docker compose exec` (it disables TTY for clean JSON). Do not use `-T` with `docker exec`.
+- Ensure the compose service is running (`docker compose up -d`) before attaching.
+
 After editing the config **restart Claude Desktop**, then test with:
 
 ```text
 @unifi-network-mcp list tools
 ```
-
-Note about Docker builds:
-
-- The image deliberately avoids copying the entire repository into the container to prevent vendored libraries (like a local `aiounifi/` folder) from shadowing PyPI dependencies. If you override the container’s filesystem (e.g., with a bind mount), avoid mounting the repo root; mount only what you need, such as `src/config` for configuration files.
 
 ### Optional HTTP SSE endpoint (off by default)
 
@@ -181,6 +198,7 @@ The server merges settings from **environment variables**, an optional `.env` fi
 | `UNIFI_PORT` | HTTPS port (default `443`) |
 | `UNIFI_SITE` | Site name (default `default`) |
 | `UNIFI_VERIFY_SSL` | Set to `false` if using self-signed certs |
+| `UNIFI_MCP_HTTP_ENABLED` | Set `true` to enable optional HTTP SSE server (default `false`) |
 
 ### `src/config/config.yaml`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   unifi-network-mcp:
     build: .
-    ports:
-      - "3000:3000"
     stdin_open: true
     tty: true
     environment:
@@ -13,6 +11,8 @@ services:
       - UNIFI_SITE=${UNIFI_SITE:-default}
       - UNIFI_VERIFY_SSL=${UNIFI_VERIFY_SSL:-false}
       - CONFIG_PATH=/app/src/config/config.yaml
+      - UNIFI_MCP_HTTP_ENABLED=${UNIFI_MCP_HTTP_ENABLED:-false}
     volumes:
       - ./src/config:/app/src/config
     restart: unless-stopped
+    container_name: unifi-network-mcp

--- a/env.example
+++ b/env.example
@@ -7,6 +7,7 @@ UNIFI_PASSWORD=changeme
 UNIFI_PORT=443
 UNIFI_SITE=default
 UNIFI_VERIFY_SSL=false
+CONFIG_PATH="src/config/config.yaml"
 
 # Optional logging level
 LOG_LEVEL=INFO 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unifi-network-mcp"
-version = "0.1.1"
+version = "0.1.2"
 description = "Unifi Network MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -10,6 +10,8 @@ server:
   host: 0.0.0.0
   port: 3000
   log_level: INFO
+  http:
+    enabled: ${oc.env:UNIFI_MCP_HTTP_ENABLED,false}
   
 permissions:
 

--- a/src/main.py
+++ b/src/main.py
@@ -165,13 +165,13 @@ async def main_async():
         async def run_http():
             try:
                 logger.info(f"Starting FastMCP HTTP SSE server on {host}:{port} ...")
-                # Prefer SSE API with explicit host/port if available
-                try:
-                    await server.run_sse_async(host=host, port=port)  # type: ignore[arg-type]
-                except TypeError:
-                    # Fallback to streamable HTTP API without args (older signatures)
-                    logger.info("Falling back to run_streamable_http_async() without host/port arguments ...")
-                    await server.run_streamable_http_async()
+                if hasattr(server, "run_sse_async"):
+                    await getattr(server, "run_sse_async")(host=host, port=port)
+                elif hasattr(server, "run_streamable_http_async"):
+                    # Older SDKs: no host/port args
+                    await getattr(server, "run_streamable_http_async")()
+                else:
+                    logger.warning("HTTP SSE not supported by this FastMCP version; skipping.")
             except Exception as http_e:
                 logger.error(f"HTTP SSE server failed to start: {http_e}")
                 logger.error(traceback.format_exc())

--- a/src/tools/stats.py
+++ b/src/tools/stats.py
@@ -27,8 +27,13 @@ async def get_network_stats(duration: str = "hourly") -> Dict[str, Any]:
         summary = {
             "total_rx_bytes": sum(e.get("rx_bytes", 0) for e in stats),
             "total_tx_bytes": sum(e.get("tx_bytes", 0) for e in stats),
-            "total_bytes": sum((e.get("rx_bytes", 0) + e.get("tx_bytes", 0)) for e in stats),
-            "avg_clients": int(sum(e.get("num_user", 0) or e.get("num_active_user", 0) for e in stats) / max(1, len(stats))) if stats else 0
+            "total_bytes": sum(
+                e.get("bytes", e.get("rx_bytes", 0) + e.get("tx_bytes", 0)) for e in stats
+            ),
+            "avg_clients": int(
+                sum(e.get("num_user", 0) or e.get("num_active_user", 0) or e.get("num_sta", 0) for e in stats)
+                / max(1, len(stats))
+            ) if stats else 0,
         }
         return {"success": True, "site": stats_manager._connection.site, "duration": duration, "summary": summary, "stats": stats}
     except Exception as e:
@@ -46,15 +51,20 @@ async def get_client_stats(client_id: str, duration: str = "hourly") -> Dict[str
         client_details = await client_manager.get_client_details(client_id)
         if not client_details:
             return {"success": False, "error": f"Client '{client_id}' not found"}
-        
-        client_name = client_details.get("name") or client_details.get("hostname") or client_details.get("mac", "Unknown")
-        actual_client_id = client_details.get("_id", client_id)
-        
-        stats = await stats_manager.get_client_stats(actual_client_id, duration_hours=duration_hours)
+
+        # Support aiounifi Client objects as well as dicts
+        client_raw = client_details.raw if hasattr(client_details, "raw") else client_details
+        client_mac = client_raw.get("mac", client_id)
+        client_name = client_raw.get("name") or client_raw.get("hostname") or client_mac
+
+        # Stats endpoint expects MAC, not _id
+        stats = await stats_manager.get_client_stats(client_mac, duration_hours=duration_hours)
         summary = {
             "total_rx_bytes": sum(e.get("rx_bytes", 0) for e in stats),
             "total_tx_bytes": sum(e.get("tx_bytes", 0) for e in stats),
-            "total_bytes": sum((e.get("rx_bytes", 0) + e.get("tx_bytes", 0)) for e in stats),
+            "total_bytes": sum(
+                e.get("bytes", e.get("rx_bytes", 0) + e.get("tx_bytes", 0)) for e in stats
+            ),
         }
         return {"success": True, "site": stats_manager._connection.site, "client_id": client_id, "client_name": client_name, "duration": duration, "summary": summary, "stats": stats}
     except Exception as e:
@@ -81,7 +91,9 @@ async def get_device_stats(device_id: str, duration: str = "hourly") -> Dict[str
         summary = {
             "total_rx_bytes": sum(e.get("rx_bytes", 0) for e in stats),
             "total_tx_bytes": sum(e.get("tx_bytes", 0) for e in stats),
-            "total_bytes": sum((e.get("rx_bytes", 0) + e.get("tx_bytes", 0)) for e in stats),
+            "total_bytes": sum(
+                e.get("bytes", e.get("rx_bytes", 0) + e.get("tx_bytes", 0)) for e in stats
+            ),
         }
         if device_type == "uap" and stats:
             summary["avg_clients"] = int(sum(e.get("num_sta", 0) for e in stats) / max(1, len(stats)))
@@ -108,10 +120,9 @@ async def get_top_clients(duration: str = "daily", limit: int = 10) -> Dict[str,
             name = "Unknown"
             if mac:
                 details = await client_manager.get_client_details(mac)
-                if details and hasattr(details, 'raw'):
-                    name = details.raw.get("name") or details.raw.get("hostname") or mac
-                elif details:
-                     name = mac
+                if details:
+                    raw = details.raw if hasattr(details, "raw") else details
+                    name = raw.get("name") or raw.get("hostname") or mac
             entry["name"] = name
             enhanced_clients.append(entry)
             


### PR DESCRIPTION
Significant updates to client and stats tools, which should now be working correctly and have built-in fallbacks. Updates to Dockerfile, ignore, and compose to improve loading and local testing.

#10 

This pull request introduces several improvements to the handling of HTTP SSE server configuration, containerization, and network statistics reporting. The changes make the HTTP SSE endpoint optional and disabled by default, improve Docker build practices to avoid dependency shadowing, and enhance the accuracy and fallback logic for network statistics and client data retrieval. Documentation and configuration files have also been updated to reflect these changes.

**Containerization and HTTP SSE server configuration:**

* The Docker build process now avoids copying the entire repository into the container to prevent vendored libraries from shadowing installed dependencies. Only necessary files (like `src/config`) are copied, and a note about this is added to the `README.md`. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L11-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R149-R166)
* The HTTP SSE endpoint is now optional and disabled by default; it can be enabled via the `UNIFI_MCP_HTTP_ENABLED` environment variable and corresponding config. Documentation and configuration files (`README.md`, `docker-compose.yml`, `config.yaml`) have been updated to reflect this change. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R84) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L4-L5) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R14-R18) [[5]](diffhunk://#diff-e9c80e728fb4364c4eb0cc0612e65bfae27ceb9501b8ca275902bc1fbd5c6f6dR13-R14)
* The main entrypoint logic in `src/main.py` now always runs the stdio server and conditionally starts the HTTP SSE server based on the config flag, with improved error handling and logging.

**Network statistics and client data improvements:**

* Fallback logic has been added to client data retrieval methods (`get_clients`, `get_all_clients`) to ensure clients are returned even if the primary API endpoints are empty, using direct UniFi API requests as backup. [[1]](diffhunk://#diff-f7ad7928d8974575e9e2cca431a31ce63883b298e77c05810e0199a2f1a28b26R36-R52) [[2]](diffhunk://#diff-f7ad7928d8974575e9e2cca431a31ce63883b298e77c05810e0199a2f1a28b26R72-R87)
* Network, client, and device statistics endpoints now use `POST` requests with payloads instead of `GET` with params, and aggregate statistics using the most accurate available attributes (`bytes`, `rx_bytes`, `tx_bytes`). Fallbacks and summary calculations have been improved for robustness. [[1]](diffhunk://#diff-f9e274e7a49c69f59fd38e6a4f66f53b8f9d433dad60def238d296ceac7de697L47-R60) [[2]](diffhunk://#diff-f9e274e7a49c69f59fd38e6a4f66f53b8f9d433dad60def238d296ceac7de697L73-R87) [[3]](diffhunk://#diff-f9e274e7a49c69f59fd38e6a4f66f53b8f9d433dad60def238d296ceac7de697L100-R114) [[4]](diffhunk://#diff-6920b03e2a1e9c2c1c79968054a25b7b131680f06cfe7440deb7544540f931e3L30-R36) [[5]](diffhunk://#diff-6920b03e2a1e9c2c1c79968054a25b7b131680f06cfe7440deb7544540f931e3L50-R67) [[6]](diffhunk://#diff-6920b03e2a1e9c2c1c79968054a25b7b131680f06cfe7440deb7544540f931e3L84-R96)

**Top clients and stats reporting:**

* The logic for determining top clients now aggregates usage from current client objects when report endpoints are unavailable, ensuring more reliable rankings. The stats tools have been updated to support both aiounifi Client objects and raw dicts for client details. [[1]](diffhunk://#diff-f9e274e7a49c69f59fd38e6a4f66f53b8f9d433dad60def238d296ceac7de697L116-R164) [[2]](diffhunk://#diff-6920b03e2a1e9c2c1c79968054a25b7b131680f06cfe7440deb7544540f931e3L111-R125)

**Documentation and configuration updates:**

* The `README.md`, `docker-compose.yml`, and `config.yaml` have been updated to clarify usage, configuration, and security notes for the HTTP SSE endpoint and container builds. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R84) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R149-R166) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L4-L5) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R14-R18) [[6]](diffhunk://#diff-e9c80e728fb4364c4eb0cc0612e65bfae27ceb9501b8ca275902bc1fbd5c6f6dR13-R14)
